### PR TITLE
Adding serviced configuration file option

### DIFF
--- a/common/tasks/services_config.yml
+++ b/common/tasks/services_config.yml
@@ -8,6 +8,7 @@
     line: "{{ item.name }}={{ item.value }}"
   with_items:
   - { name: 'SERVICED_MASTER', value: '{{ serviced_master }}' }
+  - { name: 'SERVICED_MASTER_IP', value: '{{ inventory_hostname }}' }
   - { name: 'SERVICED_SNAPSHOT', value: '0' }
   - { name: 'SERVICED_DM_BASESIZE', value: '{{ serviced_dm_basesize }}' }
   - { name: 'SERVICED_ZK', value: '{{ inventory_hostname }}:2181'}


### PR DESCRIPTION
Without this option, self-monitoring using the RMMonitor ZP will fail.